### PR TITLE
bugfix(docs): Resolved the issue of Doc not pupolating

### DIFF
--- a/src/Hng.Web/Controllers/OrganizationController.cs
+++ b/src/Hng.Web/Controllers/OrganizationController.cs
@@ -17,6 +17,11 @@ public class OrganizationController : ControllerBase
         _mediator = mediator;
     }
 
+    /// <summary>
+    /// Creates an Organization
+    /// </summary>
+    /// <param name="body"></param>
+    /// <returns></returns>
     [Authorize]
     [HttpPost]
     [ProducesResponseType(typeof(OrganizationDto), StatusCodes.Status201Created)]

--- a/src/Hng.Web/Hng.Web.csproj
+++ b/src/Hng.Web/Hng.Web.csproj
@@ -9,6 +9,8 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
+	<GenerateDocumentationFile>true</GenerateDocumentationFile>
+	<NoWarn>$(NOWarn);1591</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'https' " />

--- a/src/Hng.Web/Program.cs
+++ b/src/Hng.Web/Program.cs
@@ -5,7 +5,7 @@ using NLog.Web;
 using Hng.Application;
 using Hng.Infrastructure;
 using Microsoft.AspNetCore.Http.Json;
-using Microsoft.OpenApi.Models;
+using System.Reflection;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -18,6 +18,13 @@ builder.Services.AddApplicationConfig(builder.Configuration);
 builder.Services.AddInfrastructureConfig(builder.Configuration.GetConnectionString("DefaultConnectionString"));
 builder.Services.Configure<JsonOptions>(options => options.SerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles);
 
+builder.Services.AddSwaggerGen(c =>
+{
+    var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+    var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
+    c.IncludeXmlComments(xmlPath);
+});
+
 var app = builder.Build();
 
 await app.MigrateAndSeed();
@@ -25,7 +32,10 @@ await app.MigrateAndSeed();
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger(c => c.RouteTemplate = "docs/{documentName}/swagger.json");
-    app.UseSwaggerUI(e => e.RoutePrefix = "docs");
+    app.UseSwaggerUI(c =>
+    {
+        c.RoutePrefix = "docs";
+    });
 }
 
 app.UseGlobalErrorHandler(app.Environment);

--- a/src/Hng.Web/Properties/launchSettings.json
+++ b/src/Hng.Web/Properties/launchSettings.json
@@ -12,7 +12,7 @@
     "http": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "docs",
       "applicationUrl": "http://localhost:5288",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -22,7 +22,7 @@
     "https": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "docs",
       "applicationUrl": "https://localhost:7142;http://localhost:5288",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -32,7 +32,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "docs",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
…lating

<!-- Do not delete this PR template. Just edit it to include the required information -->

# Description

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Github Issue Example: Closes #31 -->

**Closes #issue_number_here**

# Changes proposed

## What were you told to do?
I noticed that the swagger doesn't creates the Doc.
also, the docs page doesn't pop up immediately until when editted.

## What did you do?
Fixed the issue, the docs creates now.
Also make some changes in the launch setting so that the docs page loads automatically without having to edit the url.

# Check List (Check all the applicable boxes)

🚨Please review the [contribution guideline](CONTRIBUTING.md) for this repository.

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [X] My code follows the code style of this project.
- [X] This PR does not contain plagiarized content.
- [X] The title and description of the PR is clear and explains the approach.
- [X] I am making a pull request against the **dev branch** (left side).
- [X] My commit messages styles matches our requested structure.
- [X] My code additions will fail neither code linting checks nor unit test.
- [X] I am only making changes to files I was requested to.

# Screenshots/Videos
![image](https://github.com/user-attachments/assets/58a9191b-0552-4fa4-ba3b-6ae659c75563)

<!-- If the changes are static page changes or UI changes add screenshots -->
<!-- If the changes involve implementing a functionality or working with apis, include a video
detailing how to implement the functionality and the request to the api and responses from the api endpoint-->
<!-- Add all the screenshots/videos which support your changes i.e before your change and after your change -->