### PR TITLE
Prevent Deployment on Fork Repositories for Dev, Staging, and Production

### DIFF
--- a/.github/workflows/dev-deployment.yml
+++ b/.github/workflows/dev-deployment.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   deploy_to_dev:
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
 
     environment:

--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   deploy_to_production:
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
 
     environment:

--- a/.github/workflows/staging-deployment.yml
+++ b/.github/workflows/staging-deployment.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   deploy_to_staging:
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
 
     environment:


### PR DESCRIPTION
### Description
This pull request updates the CI/CD configuration to prevent deployments to development, staging, and production environments from forked repositories.

### Objective
Enhance the deployment process by ensuring that deployments from forked repositories are restricted, thereby avoiding potential issues and ensuring that only trusted sources can deploy to critical environments.

### Changes Made
- **Updated the CI/CD Workflow:** Modified the github worflows to include a condition that prevents deployments from forked repositories.
- **Scope:** The change applies to all environments: development, staging, and production.
- **Configuration Improvement:** Added a check to ensure that the deployment job only runs if the repository is not a fork.

### Checklist
- 🚨 Please review the contribution guideline for this repository.
- Code adheres to the project's style guidelines.
- This PR does not include plagiarized content.
- The title and description of the PR clearly outline the changes made.
- The PR targets the dev branch.
- Commit messages follow the specified format.
- Code changes pass all linting checks and unit tests.
- Modifications are limited to the necessary files.