### PR TITLE
feat: comments - get comments by blog id

### DIFF
--- a/src/Hng.Application.Test/Features/Comment/GetCommentsByBlogIdShould.cs
+++ b/src/Hng.Application.Test/Features/Comment/GetCommentsByBlogIdShould.cs
@@ -54,6 +54,6 @@ namespace Hng.Application.Test.Features.Comment
             Assert.Equal("Test Comment 1", commentDtos[0].Content);
             Assert.Equal("Test Comment 2", commentDtos[1].Content);
         }
-        
+
     }
 }

--- a/src/Hng.Application.Test/Features/Comment/GetCommentsByBlogIdShould.cs
+++ b/src/Hng.Application.Test/Features/Comment/GetCommentsByBlogIdShould.cs
@@ -1,0 +1,59 @@
+﻿using System.Linq.Expressions;
+using AutoMapper;
+using Hng.Application.Features.Comments.Dtos;
+using Hng.Application.Features.Comments.Handlers;
+using Hng.Application.Features.Comments.Queries;
+using Hng.Infrastructure.Repository.Interface;
+using Moq;
+using Xunit;
+
+namespace Hng.Application.Test.Features.Comment
+{
+    public class GetCommentsByBlogIdQueryShould
+    {
+        private readonly Mock<IRepository<Domain.Entities.Comment>> _commentRepositoryMock;
+        private readonly GetCommentsByBlogIdQueryHandler _handler;
+
+        public GetCommentsByBlogIdQueryShould()
+        {
+            _commentRepositoryMock = new Mock<IRepository<Domain.Entities.Comment>>();
+
+            var config = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Domain.Entities.Comment, CommentDto>().ReverseMap();
+            });
+
+            var mapper = config.CreateMapper();
+            _handler = new GetCommentsByBlogIdQueryHandler(mapper, _commentRepositoryMock.Object);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldReturnComments_WhenBlogExists()
+        {
+            // Arrange
+            var blogId = Guid.NewGuid();
+            var comments = new List<Domain.Entities.Comment>
+            {
+                new() { Id = Guid.NewGuid(), BlogId = blogId, Content = "Test Comment 1" },
+                new() { Id = Guid.NewGuid(), BlogId = blogId, Content = "Test Comment 2" }
+            };
+            var blog = new Domain.Entities.Blog { Id = blogId, Title = "Test Blog" };
+
+            _commentRepositoryMock.Setup(r => r.GetAllBySpec(
+                    It.IsAny<Expression<Func<Domain.Entities.Comment, bool>>>()))
+                .ReturnsAsync(comments);
+
+            var query = new GetCommentsByBlogIdQuery(blogId);
+
+            // Act
+            var result = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            var commentDtos = result as CommentDto[] ?? result.ToArray();
+            Assert.Equal("Test Comment 1", commentDtos[0].Content);
+            Assert.Equal("Test Comment 2", commentDtos[1].Content);
+        }
+        
+    }
+}

--- a/src/Hng.Application/Features/Blogs/Dtos/CreateBlogDto.cs
+++ b/src/Hng.Application/Features/Blogs/Dtos/CreateBlogDto.cs
@@ -13,5 +13,8 @@ public class CreateBlogDto
     [JsonConverter(typeof(JsonStringEnumConverter))]
     [JsonPropertyName("category")]
     public BlogCategory Category { get; set; }
+    
+    [JsonPropertyName("image_url")]
+    public string ImageUrl { get; set; }
 }
 

--- a/src/Hng.Application/Features/Blogs/Dtos/CreateBlogDto.cs
+++ b/src/Hng.Application/Features/Blogs/Dtos/CreateBlogDto.cs
@@ -13,7 +13,7 @@ public class CreateBlogDto
     [JsonConverter(typeof(JsonStringEnumConverter))]
     [JsonPropertyName("category")]
     public BlogCategory Category { get; set; }
-    
+
     [JsonPropertyName("image_url")]
     public string ImageUrl { get; set; }
 }

--- a/src/Hng.Application/Features/Comments/Handlers/GetCommentsByBlogIdQueryHandler.cs
+++ b/src/Hng.Application/Features/Comments/Handlers/GetCommentsByBlogIdQueryHandler.cs
@@ -1,0 +1,20 @@
+﻿using AutoMapper;
+using Hng.Application.Features.Comments.Dtos;
+using Hng.Application.Features.Comments.Queries;
+using Hng.Domain.Entities;
+using Hng.Infrastructure.Repository.Interface;
+using MediatR;
+
+namespace Hng.Application.Features.Comments.Handlers;
+
+public class GetCommentsByBlogIdQueryHandler(IMapper mapper, IRepository<Comment> commentRepository) : IRequestHandler<GetCommentsByBlogIdQuery, IEnumerable<CommentDto>>
+{
+    private readonly IRepository<Comment> _commentRepository = commentRepository;
+    private readonly IMapper _mapper = mapper;
+    
+    public async Task<IEnumerable<CommentDto>> Handle(GetCommentsByBlogIdQuery request, CancellationToken cancellationToken)
+    {
+        var comments = await _commentRepository.GetAllBySpec(c => c.BlogId == request.BlogId);
+        return _mapper.Map<IEnumerable<CommentDto>>(comments);
+    }
+}

--- a/src/Hng.Application/Features/Comments/Handlers/GetCommentsByBlogIdQueryHandler.cs
+++ b/src/Hng.Application/Features/Comments/Handlers/GetCommentsByBlogIdQueryHandler.cs
@@ -11,7 +11,7 @@ public class GetCommentsByBlogIdQueryHandler(IMapper mapper, IRepository<Comment
 {
     private readonly IRepository<Comment> _commentRepository = commentRepository;
     private readonly IMapper _mapper = mapper;
-    
+
     public async Task<IEnumerable<CommentDto>> Handle(GetCommentsByBlogIdQuery request, CancellationToken cancellationToken)
     {
         var comments = await _commentRepository.GetAllBySpec(c => c.BlogId == request.BlogId);

--- a/src/Hng.Application/Features/Comments/Queries/GetCommentsByBlogIdQuery.cs
+++ b/src/Hng.Application/Features/Comments/Queries/GetCommentsByBlogIdQuery.cs
@@ -1,0 +1,9 @@
+﻿using Hng.Application.Features.Comments.Dtos;
+using MediatR;
+
+namespace Hng.Application.Features.Comments.Queries;
+
+public class GetCommentsByBlogIdQuery(Guid blogId) : IRequest<IEnumerable<CommentDto>>
+{
+    public Guid BlogId { get; set; } = blogId;
+}

--- a/src/Hng.Application/Hng.Application.csproj
+++ b/src/Hng.Application/Hng.Application.csproj
@@ -33,7 +33,6 @@
   </ItemGroup>
 
   <ItemGroup>
-  <Folder Include="Features\Comments\Queries\" />
   <Folder Include="Features\Jobs\Queries\" />
    <Folder Include="Features\SuperAdmin\Commands\" />
   <Folder Include="Features\UserManagement\Commands\" />

--- a/src/Hng.Web/Controllers/CommentController.cs
+++ b/src/Hng.Web/Controllers/CommentController.cs
@@ -1,5 +1,7 @@
 ﻿using Hng.Application.Features.Comments.Commands;
 using Hng.Application.Features.Comments.Dtos;
+using Hng.Application.Features.Comments.Queries;
+using Hng.Application.Shared.Dtos;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -20,5 +22,19 @@ public class CommentController(IMediator mediator) : ControllerBase
         var command = new CreateCommentCommand(body, blogId);
         var result = await _mediator.Send(command);
         return Ok(result);
+    }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(CommentDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(FailureResponseDto<string>), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<IEnumerable<CommentDto>>> GetCommentsByBlogId([FromRoute] Guid blogId)
+    {
+        var query = new GetCommentsByBlogIdQuery(blogId);
+        var comments = await _mediator.Send(query);
+        var response = new SuccessResponseDto<IEnumerable<CommentDto>>
+        {
+            Data = comments
+        };
+        return Ok(response);
     }
 }

--- a/src/Hng.Web/Controllers/CommentController.cs
+++ b/src/Hng.Web/Controllers/CommentController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Hng.Web.Controllers;
 
+[Authorize]
 [ApiController]
 [Route("api/v1")]
 public class CommentController : ControllerBase

--- a/src/Hng.Web/Controllers/CommentController.cs
+++ b/src/Hng.Web/Controllers/CommentController.cs
@@ -8,19 +8,12 @@ namespace Hng.Web.Controllers;
 
 [Authorize]
 [ApiController]
-[Route("api/v1")]
-public class CommentController : ControllerBase
+[Route("api/v1/posts/{blogId:guid}/comments")]
+public class CommentController(IMediator mediator) : ControllerBase
 {
+    private readonly IMediator _mediator = mediator;
 
-    private readonly IMediator _mediator;
-
-    public CommentController(IMediator mediator)
-    {
-        _mediator = mediator;
-    }
-
-    [Authorize]
-    [HttpPost("posts/{blogId:guid}/comments")]
+    [HttpPost]
     [ProducesResponseType(typeof(CommentDto), StatusCodes.Status201Created)]
     public async Task<ActionResult<CommentDto>> CreateComment([FromRoute] Guid blogId, [FromBody] CreateCommentDto body)
     {


### PR DESCRIPTION
<!-- Do not delete this PR template. Just edit it to include the required information -->

# Description
Implement an endpoint to retrieve comments associated with a specific blog post by its ID.
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Github Issue Example: Closes #31 -->

**Closes #215 **

### Details

- `Endpoint Implementation:` Added a new `GET /api/v1/{blogId}/comments` endpoint.
- `DTO Creation:` Created the CommentDto class to represent the data transfer object for comments.
- `Handler Implementation:`

    - Created a handler to process the request and fetch comments by blogId.
    - Added logic to query the database and return comments in the CommentDto format.

- `Validation:` Implemented validation for the blogId parameter.
- `Error Handling:` Added error handling for cases where the blog post ID does not exist.
- `Unit Tests:` Developed unit tests to ensure the endpoint functions correctly.