### PR TITLE
feat(notification): Get notification

### DIFF
--- a/src/Hng.Application.Test/Features/Notifications/GetAllNotificationsHandlerShould.cs
+++ b/src/Hng.Application.Test/Features/Notifications/GetAllNotificationsHandlerShould.cs
@@ -1,0 +1,87 @@
+﻿using AutoMapper;
+using Hng.Application.Features.Notifications.Mappers;
+using Hng.Application.Features.Notifications.Queries;
+using Hng.Domain.Entities;
+using Hng.Infrastructure.Repository.Interface;
+using Hng.Infrastructure.Services.Interfaces;
+using Moq;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Hng.Application.Test.Features.Notifications
+{
+    public class GetAllNotificationsHandlerShould
+    {
+        private readonly IMapper _mapper;
+        private readonly Mock<IRepository<Notification>> _mockNotificationRepository;
+        private readonly Mock<IAuthenticationService> _mockAuthenticationService;
+        private readonly GetAllNotificationsHandler _handler;
+
+        public GetAllNotificationsHandlerShould()
+        {
+            var mappingProfile = new NotificationMapperProfile();
+            var configuration = new MapperConfiguration(cfg => cfg.AddProfile(mappingProfile));
+            _mapper = new Mapper(configuration);
+
+            _mockNotificationRepository = new Mock<IRepository<Notification>>();
+            _mockAuthenticationService = new Mock<IAuthenticationService>();
+            _handler = new GetAllNotificationsHandler(_mockNotificationRepository.Object, _mockAuthenticationService.Object, _mapper);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldReturnNotificationsWhenFound()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var query = new GetAllNotificationsQuery();
+
+            var notifications = new List<Notification>
+            {
+                new Notification { Id = Guid.NewGuid(), UserId = userId, IsRead = false, Message = "New notification", CreatedAt = DateTime.UtcNow },
+                new Notification { Id = Guid.NewGuid(), UserId = userId, IsRead = true, Message = "Old notification", CreatedAt = DateTime.UtcNow }
+            };
+
+            _mockAuthenticationService.Setup(a => a.GetCurrentUserAsync())
+                .ReturnsAsync(userId);
+
+            _mockNotificationRepository.Setup(r => r.GetAllBySpec(It.IsAny<Expression<Func<Notification, bool>>>()))
+                .ReturnsAsync(notifications);
+
+            // Act
+            var result = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(notifications.Count, result.TotalNotificationCount);
+            Assert.Equal(notifications.Count(n => !n.IsRead), result.TotalUnreadNotificationCount);
+            Assert.Equal(notifications.Count, result.Notifications.Count);
+
+            _mockNotificationRepository.Verify(r => r.GetAllBySpec(It.Is<Expression<Func<Notification, bool>>>(expr => expr.Compile()(notifications[0]))), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldReturnEmptyWhenNoNotificationsFound()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var query = new GetAllNotificationsQuery();
+
+            _mockAuthenticationService.Setup(a => a.GetCurrentUserAsync())
+                .ReturnsAsync(userId);
+
+            _mockNotificationRepository.Setup(r => r.GetAllBySpec(It.IsAny<Expression<Func<Notification, bool>>>()))
+                .ReturnsAsync(new List<Notification>());
+
+            // Act
+            var result = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(0, result.TotalNotificationCount);
+            Assert.Equal(0, result.TotalUnreadNotificationCount);
+            Assert.Empty(result.Notifications);
+
+            _mockNotificationRepository.Verify(r => r.GetAllBySpec(It.IsAny<Expression<Func<Notification, bool>>>()), Times.Once);
+        }
+    }
+}

--- a/src/Hng.Application.Test/Features/Notifications/GetNotificationsHandlerShould.cs
+++ b/src/Hng.Application.Test/Features/Notifications/GetNotificationsHandlerShould.cs
@@ -1,0 +1,118 @@
+﻿using AutoMapper;
+using Hng.Application.Features.Notifications.Handlers;
+using Hng.Application.Features.Notifications.Mappers;
+using Hng.Application.Features.Notifications.Queries;
+using Hng.Domain.Entities;
+using Hng.Infrastructure.Repository.Interface;
+using Hng.Infrastructure.Services.Interfaces;
+using Moq;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Hng.Application.Test.Features.Notifications
+{
+    public class GetNotificationsHandlerShould
+    {
+        private readonly IMapper _mapper;
+        private readonly Mock<IRepository<Notification>> _mockNotificationRepository;
+        private readonly Mock<IAuthenticationService> _mockAuthenticationService;
+        private readonly GetNotificationsHandler _handler;
+
+        public GetNotificationsHandlerShould()
+        {
+            var mappingProfile = new NotificationMapperProfile();
+            var configuration = new MapperConfiguration(cfg => cfg.AddProfile(mappingProfile));
+            _mapper = new Mapper(configuration);
+
+            _mockNotificationRepository = new Mock<IRepository<Notification>>();
+            _mockAuthenticationService = new Mock<IAuthenticationService>();
+            _handler = new GetNotificationsHandler(_mockNotificationRepository.Object, _mockAuthenticationService.Object, _mapper);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldReturnNotificationsWhenFound()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var query = new GetNotificationsQuery(null);
+
+            var notifications = new List<Notification>
+            {
+                new Notification { Id = Guid.NewGuid(), UserId = userId, IsRead = false, Message = "New notification", CreatedAt = DateTime.UtcNow },
+                new Notification { Id = Guid.NewGuid(), UserId = userId, IsRead = true, Message = "Old notification", CreatedAt = DateTime.UtcNow }
+            };
+
+            _mockAuthenticationService.Setup(a => a.GetCurrentUserAsync())
+                .ReturnsAsync(userId);
+
+            _mockNotificationRepository.Setup(r => r.GetAllBySpec(It.IsAny<Expression<Func<Notification, bool>>>()))
+                .ReturnsAsync(notifications);
+
+            // Act
+            var result = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(notifications.Count, result.TotalNotificationCount);
+            Assert.Equal(notifications.Count(n => !n.IsRead), result.TotalUnreadNotificationCount);
+            Assert.Equal(notifications.Count, result.Notifications.Count);
+
+            _mockNotificationRepository.Verify(r => r.GetAllBySpec(It.Is<Expression<Func<Notification, bool>>>(expr => expr.Compile()(notifications[0]))), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldReturnEmptyWhenNoNotificationsFound()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var query = new GetNotificationsQuery(null);
+
+            _mockAuthenticationService.Setup(a => a.GetCurrentUserAsync())
+                .ReturnsAsync(userId);
+
+            _mockNotificationRepository.Setup(r => r.GetAllBySpec(It.IsAny<Expression<Func<Notification, bool>>>()))
+                .ReturnsAsync(new List<Notification>());
+
+            // Act
+            var result = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(0, result.TotalNotificationCount);
+            Assert.Equal(0, result.TotalUnreadNotificationCount);
+            Assert.Empty(result.Notifications);
+
+            _mockNotificationRepository.Verify(r => r.GetAllBySpec(It.IsAny<Expression<Func<Notification, bool>>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldFilterByReadStatusWhenSpecified()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var query = new GetNotificationsQuery(true);
+
+            var notifications = new List<Notification>
+            {
+                new Notification { Id = Guid.NewGuid(), UserId = userId, IsRead = true, Message = "Read notification", CreatedAt = DateTime.UtcNow },
+                new Notification { Id = Guid.NewGuid(), UserId = userId, IsRead = false, Message = "Unread notification", CreatedAt = DateTime.UtcNow }
+            };
+
+            _mockAuthenticationService.Setup(a => a.GetCurrentUserAsync())
+                .ReturnsAsync(userId);
+
+            _mockNotificationRepository.Setup(r => r.GetAllBySpec(It.IsAny<Expression<Func<Notification, bool>>>()))
+                .ReturnsAsync(notifications);
+
+            // Act
+            var result = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Single(result.Notifications);
+            Assert.True(result.Notifications.All(n => n.IsRead));
+
+            _mockNotificationRepository.Verify(r => r.GetAllBySpec(It.Is<Expression<Func<Notification, bool>>>(expr => expr.Compile()(notifications[0]))), Times.Once);
+        }
+    }
+}

--- a/src/Hng.Application/Features/Notifications/Dtos/GetNotificationsResponseDto.cs
+++ b/src/Hng.Application/Features/Notifications/Dtos/GetNotificationsResponseDto.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hng.Application.Features.Notifications.Dtos
+{
+    public class GetNotificationsResponseDto
+    {
+        public int TotalNotificationCount { get; set; }
+        public int TotalUnreadNotificationCount { get; set; }
+        public List<NotificationDto> Notifications { get; set; }
+    }
+}

--- a/src/Hng.Application/Features/Notifications/Handlers/GetAllNotificationsHandler.cs
+++ b/src/Hng.Application/Features/Notifications/Handlers/GetAllNotificationsHandler.cs
@@ -1,0 +1,39 @@
+﻿using AutoMapper;
+using Hng.Application.Features.Notifications.Dtos;
+using Hng.Application.Features.Notifications.Queries;
+using Hng.Domain.Entities;
+using Hng.Infrastructure.Repository.Interface;
+using Hng.Infrastructure.Services.Interfaces;
+using MediatR;
+
+public class GetAllNotificationsHandler : IRequestHandler<GetAllNotificationsQuery, GetNotificationsResponseDto>
+{
+    private readonly IRepository<Notification> _notificationRepository;
+    private readonly IAuthenticationService _authenticationService;
+    private readonly IMapper _mapper;
+
+    public GetAllNotificationsHandler(IRepository<Notification> notificationRepository, IAuthenticationService authenticationService, IMapper mapper)
+    {
+        _notificationRepository = notificationRepository;
+        _authenticationService = authenticationService;
+        _mapper = mapper;
+    }
+
+    public async Task<GetNotificationsResponseDto> Handle(GetAllNotificationsQuery request, CancellationToken cancellationToken)
+    {
+        var userId = await _authenticationService.GetCurrentUserAsync();
+        var notifications = await _notificationRepository.GetAllBySpec(n => n.UserId == userId);
+
+        var totalNotificationCount = notifications.Count();
+        var totalUnreadNotificationCount = notifications.Count(n => !n.IsRead);
+
+        var notificationDtos = _mapper.Map<List<NotificationDto>>(notifications);
+
+        return new GetNotificationsResponseDto
+        {
+            TotalNotificationCount = totalNotificationCount,
+            TotalUnreadNotificationCount = totalUnreadNotificationCount,
+            Notifications = notificationDtos
+        };
+    }
+}

--- a/src/Hng.Application/Features/Notifications/Handlers/GetNotificationsHandler.cs
+++ b/src/Hng.Application/Features/Notifications/Handlers/GetNotificationsHandler.cs
@@ -1,0 +1,50 @@
+﻿using AutoMapper;
+using Hng.Application.Features.Notifications.Dtos;
+using Hng.Application.Features.Notifications.Queries;
+using Hng.Domain.Entities;
+using Hng.Infrastructure.Repository.Interface;
+using MediatR;
+using Hng.Infrastructure.Services.Interfaces;
+
+namespace Hng.Application.Features.Notifications.Handlers
+{
+    public class GetNotificationsHandler : IRequestHandler<GetNotificationsQuery, GetNotificationsResponseDto>
+    {
+        private readonly IRepository<Notification> _notificationRepository;
+        private readonly IAuthenticationService _authenticationService;
+        private readonly IMapper _mapper;
+
+        public GetNotificationsHandler(
+            IRepository<Notification> notificationRepository,
+            IAuthenticationService authenticationService,
+            IMapper mapper)
+        {
+            _notificationRepository = notificationRepository;
+            _authenticationService = authenticationService;
+            _mapper = mapper;
+        }
+
+        public async Task<GetNotificationsResponseDto> Handle(GetNotificationsQuery request, CancellationToken cancellationToken)
+        {
+            var userId = await _authenticationService.GetCurrentUserAsync();
+            var notifications = await _notificationRepository.GetAllBySpec(n => n.UserId == userId);
+
+            if (request.IsRead.HasValue)
+            {
+                notifications = notifications.Where(n => n.IsRead == request.IsRead.Value).ToList();
+            }
+
+            var totalNotificationCount = notifications.Count();
+            var totalUnreadNotificationCount = notifications.Count(n => !n.IsRead);
+
+            var notificationDtos = _mapper.Map<List<NotificationDto>>(notifications);
+
+            return new GetNotificationsResponseDto
+            {
+                TotalNotificationCount = totalNotificationCount,
+                TotalUnreadNotificationCount = totalUnreadNotificationCount,
+                Notifications = notificationDtos
+            };
+        }
+    }
+}

--- a/src/Hng.Application/Features/Notifications/Queries/GetAllNotificationsQuery.cs
+++ b/src/Hng.Application/Features/Notifications/Queries/GetAllNotificationsQuery.cs
@@ -1,0 +1,9 @@
+﻿using Hng.Application.Features.Notifications.Dtos;
+using MediatR;
+
+namespace Hng.Application.Features.Notifications.Queries
+{
+    public class GetAllNotificationsQuery : IRequest<GetNotificationsResponseDto>
+    {
+    }
+}

--- a/src/Hng.Application/Features/Notifications/Queries/GetNotificationsQuery.cs
+++ b/src/Hng.Application/Features/Notifications/Queries/GetNotificationsQuery.cs
@@ -1,0 +1,15 @@
+﻿using Hng.Application.Features.Notifications.Dtos;
+using MediatR;
+
+namespace Hng.Application.Features.Notifications.Queries
+{
+    public class GetNotificationsQuery : IRequest<GetNotificationsResponseDto>
+    {
+        public bool? IsRead { get; set; }
+
+        public GetNotificationsQuery(bool? isRead)
+        {
+            IsRead = isRead;
+        }
+    }
+}

--- a/src/Hng.Web/Controllers/NotificationController.cs
+++ b/src/Hng.Web/Controllers/NotificationController.cs
@@ -1,5 +1,6 @@
 ﻿using Hng.Application.Features.Notifications.Commands;
 using Hng.Application.Features.Notifications.Dtos;
+using Hng.Application.Features.Notifications.Queries;
 using Hng.Application.Shared.Dtos;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -44,6 +45,66 @@ namespace Hng.Web.Controllers
             catch (Exception ex)
             {
                 return BadRequest(new FailureResponseDto<object> { Error = "Bad Request", Message = ex.Message, Data = false });
+            }
+        }
+
+        /// <summary>
+        /// Retrieve user's notifications (Read + Unread)
+        /// </summary>
+        [HttpGet("GetAll")]
+        [ProducesResponseType(typeof(SuccessResponseDto<GetNotificationsResponseDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(FailureResponseDto<object>), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(FailureResponseDto<object>), StatusCodes.Status401Unauthorized)]
+        public async Task<IActionResult> GetAllNotifications()
+        {
+            try
+            {
+                var query = new GetAllNotificationsQuery();
+                var response = await _mediator.Send(query);
+                return Ok(new SuccessResponseDto<GetNotificationsResponseDto>
+                {
+                    Message = "Notifications retrieved successfully",
+                    Data = response
+                });
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(new FailureResponseDto<object>
+                {
+                    Error = "Bad Request",
+                    Message = ex.Message,
+                    Data = false
+                });
+            }
+        }
+        /// <summary>
+        /// Retrieve user's notifications (Read or Unread) 
+        /// </summary>
+        [HttpGet]
+        [ProducesResponseType(typeof(SuccessResponseDto<GetNotificationsResponseDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(FailureResponseDto<object>), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(FailureResponseDto<object>), StatusCodes.Status401Unauthorized)]
+        public async Task<IActionResult> GetNotifications([FromQuery] bool? is_read)
+        {
+            try
+            {
+                var query = new GetNotificationsQuery(is_read);
+                var response = await _mediator.Send(query);
+                return Ok(new SuccessResponseDto<GetNotificationsResponseDto>
+                {
+                    Message = is_read.HasValue && is_read.Value == false ? "Unread notifications retrieved successfully" : "Notifications retrieved successfully",
+
+                    Data = response
+                });
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(new FailureResponseDto<object>
+                {
+                    Error = "Bad Request",
+                    Message = ex.Message,
+                    Data = false
+                });
             }
         }
     }

--- a/src/Hng.Web/Extensions/MigrateAndSeedExtension.cs
+++ b/src/Hng.Web/Extensions/MigrateAndSeedExtension.cs
@@ -11,7 +11,7 @@ namespace Hng.Web.Extensions
             var scope = app.Services.CreateScope();
             var seeder = scope.ServiceProvider.GetRequiredService<SeederService>();
             var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-            context.Database.EnsureDeleted();
+            // context.Database.EnsureDeleted();
             context.Database.Migrate();
             await seeder.SeedUsers();
             await seeder.SeedProfile();


### PR DESCRIPTION
<!-- Do not delete this PR template. Just edit it to include the required information -->

# Description

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->
This PR introduces two endpoints for retrieving notifications for authenticated users. The first endpoint retrieves all notifications, while the second allows filtering notifications based on their read/unread status.
<!-- Github Issue Example: Closes #31 -->
**Features Implemented:**
- Notification Retrieval: Provides two methods to retrieve notifications based on user requirements.
- Authentication: Ensures that only authenticated users can access their notifications.
- Filtering: Allows filtering of notifications based on read/unread status for one of the endpoints.
- Error Handling: Manages errors for unauthenticated users, invalid requests, and other issues.

**Closes #issue_number_here**

# Changes proposed
1. **Retrieve All Notifications**
- Endpoint: GET /api/v1/notifications/GetAll
- Summary: Retrieve all notifications for the authenticated user.

**Successful Response:**

- Status Code: 200 OK
- Response 
```json 
{
  "message": "Notifications retrieved successfully",
  "data": {
    "total_notification_count": 5,
    "total_unread_notification_count": 2,
    "notifications": [
      {
        "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
        "user_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
        "is_read": true,
        "message": "Notification message",
        "created_at": "2024-08-06T17:26:12.357Z",
        "updated_at": "2024-08-06T17:26:12.357Z"
      }
      // additional notifications
    ]
  }
}
```
**Error Responses:**

- Bad Request:

- Status Code: 400 Bad Request
- Response

```json
{
  "error": "Bad Request",
  "message": "Invalid request",
  "data": false
}
```

2. **Retrieve Notifications by Read Status**
- Endpoint: GET /api/v1/notifications
- Summary: Retrieve notifications for the authenticated user, with the option to filter by read/unread status.
- Query Parameter: is_read (optional, boolean) - Filter notifications based on their read status.

**Successful Response:**
- Status Code: 200 OK
- Response 

```json
{
  "message": "Notifications retrieved successfully",
  "data": {
    "total_notification_count": 5,
    "total_unread_notification_count": 2,
    "notifications": [
      {
        "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
        "user_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
        "is_read": false,
        "message": "Unread notification",
        "created_at": "2024-08-06T17:26:12.357Z",
        "updated_at": "2024-08-06T17:26:12.357Z"
      }
      // additional notifications
    ]
  }
}
```
**Error Responses:**

- Bad Request:

- Status Code: 400 Bad Request
- Response

```json
{
  "error": "Bad Request",
  "message": "Invalid query parameters or other request issues",
  "data": false
}
```

## What were you told to do?
Implement endpoints for retrieving notifications with and without filtering by read status.
<!-- Write the title of the issue/feature you are working on -->

## What did you do?
- Created two endpoints: one for retrieving all notifications and one for filtering by read/unread status.
- Handled successful retrieval and various error scenarios.
<!-- Talk about the things you did eg. files changes, dependencies installed e.t.c -->

# Check List (Check all the applicable boxes)

🚨Please review the [contribution guideline](CONTRIBUTING.md) for this repository.

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the **dev branch** (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

# Screenshots/Videos

<!-- If the changes are static page changes or UI changes add screenshots -->
<!-- If the changes involve implementing a functionality or working with apis, include a video
detailing how to implement the functionality and the request to the api and responses from the api endpoint-->
<!-- Add all the screenshots/videos which support your changes i.e before your change and after your change -->