### PR TITLE
fix: user - fixed the route for switch user organisation

### DIFF
--- a/src/Hng.Web/Controllers/UserController.cs
+++ b/src/Hng.Web/Controllers/UserController.cs
@@ -38,7 +38,7 @@ public class UserController(IMediator mediator) : ControllerBase
         return Ok(users);
     }
 
-    [HttpPut("/organisations/{organisationId:guid}")]
+    [HttpPut("organisations/{organisationId:guid}")]
     public async Task<IActionResult> SwitchUserOrganisation(
         Guid organisationId,
         [FromBody] SwitchOrganisationRequestDto request)


### PR DESCRIPTION
<!-- Do not delete this PR template. Just edit it to include the required information -->

# Description

Updated the HttpPut route for SwitchUserOrganisation by removing the leading slash. This ensures the route correctly appends to the controller's base route `(api/v1/users)`.

### Result
The full route for the SwitchUserOrganisation endpoint is now correctly displayed as `api/v1/users/organisations/{organisationId:guid}`.
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Github Issue Example: Closes #31 -->

**Closes #issue_number_here**

# Changes proposed

your changes i.e before your change and after your change -->