### PR TITLE
fix: match Swagger docs to actual invite responses for OrganizationInvite

### DIFF
--- a/src/Hng.Application/Features/OrganisationInvite/Commands/CreateAndSendInvitesCommand.cs
+++ b/src/Hng.Application/Features/OrganisationInvite/Commands/CreateAndSendInvitesCommand.cs
@@ -4,4 +4,4 @@ using MediatR;
 
 namespace Hng.Application.Features.OrganisationInvite.Commands;
 
-public record CreateAndSendInvitesCommand(CreateAndSendInvitesDto Details) : IRequest<StatusCodeResponse<object>>;
+public record CreateAndSendInvitesCommand(CreateAndSendInvitesDto Details) : IRequest<StatusCodeResponse>;

--- a/src/Hng.Application/Features/OrganisationInvite/Commands/CreateOrganizationInviteCommand.cs
+++ b/src/Hng.Application/Features/OrganisationInvite/Commands/CreateOrganizationInviteCommand.cs
@@ -4,5 +4,5 @@ using Hng.Application.Shared.Dtos;
 
 namespace Hng.Application.Features.OrganisationInvite.Commands;
 
-public record CreateOrganizationInviteCommand(CreateOrganizationInviteDto InviteDto) : IRequest<StatusCodeResponse<OrganizationInviteDto>>;
+public record CreateOrganizationInviteCommand(CreateOrganizationInviteDto InviteDto) : IRequest<StatusCodeResponse>;
 

--- a/src/Hng.Application/Features/OrganisationInvite/Handlers/CreateAndSendInvitesCommandHandler.cs
+++ b/src/Hng.Application/Features/OrganisationInvite/Handlers/CreateAndSendInvitesCommandHandler.cs
@@ -21,7 +21,7 @@ public class CreateAndSendInvitesCommandHandler(
     , IRequestValidator requestValidator) :
 
     IRequestHandler<CreateAndSendInvitesCommand,
-    StatusCodeResponse<object>>
+    StatusCodeResponse>
 {
     private readonly IOrganisationInviteService inviteService = inviteService;
     private readonly IMessageQueueService queueService = queueService;
@@ -30,7 +30,7 @@ public class CreateAndSendInvitesCommandHandler(
     private readonly IRepository<OrganizationInvite> inviteRepository = inviteRepository;
     private readonly IRequestValidator requestValidator = requestValidator;
 
-    public async Task<StatusCodeResponse<object>> Handle(CreateAndSendInvitesCommand request, CancellationToken cancellationToken)
+    public async Task<StatusCodeResponse> Handle(CreateAndSendInvitesCommand request, CancellationToken cancellationToken)
     {
         Guid orgId = Guid.Parse(request.Details.OrgId);
 
@@ -50,7 +50,7 @@ public class CreateAndSendInvitesCommandHandler(
             inviteList.Add(await CreateAndSendInvites(user, organization, email, inviteRepository));
         }
 
-        return new StatusCodeResponse<object>
+        return new StatusCodeResponse
         {
             StatusCode = StatusCodes.Status200OK,
             Message = "Invitation(s) processed successfully!",
@@ -89,9 +89,9 @@ public class CreateAndSendInvitesCommandHandler(
         return validationResult;
     }
 
-    private static StatusCodeResponse<object> ErrorResponse(Result<Organization> errorResult)
+    private static StatusCodeResponse ErrorResponse(Result<Organization> errorResult)
     {
-        return new StatusCodeResponse<object>()
+        return new StatusCodeResponse()
         {
             Message = errorResult.Error.Message,
             StatusCode = errorResult.Error switch

--- a/src/Hng.Application/Shared/Dtos/ControllerSuccessResponse.cs
+++ b/src/Hng.Application/Shared/Dtos/ControllerSuccessResponse.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace Hng.Application.Shared.Dtos;
+
+//useful for annotating methods for swagger
+public class ControllerStatusResponse<T>
+{
+
+    [JsonPropertyName("status_code")]
+    public int StatusCode { get; set; }
+
+    [JsonPropertyName("message")]
+    public string Message { get; set; }
+
+    [JsonPropertyName("data")]
+    public T Data { get; set; }
+}
+

--- a/src/Hng.Application/Shared/Dtos/StatusCodeResponse.cs
+++ b/src/Hng.Application/Shared/Dtos/StatusCodeResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Hng.Application.Shared.Dtos
 {
-    public class StatusCodeResponse<T>()
+    public class StatusCodeResponse
     {
         [JsonPropertyName("status_code")]
         public int StatusCode { get; set; }
@@ -16,3 +16,5 @@ namespace Hng.Application.Shared.Dtos
     }
 
 }
+
+

--- a/src/Hng.Web/Controllers/OrganizationController.cs
+++ b/src/Hng.Web/Controllers/OrganizationController.cs
@@ -116,41 +116,40 @@ public class OrganizationController(IMediator mediator, IAuthenticationService a
         return StatusCode(response.StatusCode, response);
     }
 
-    /// <summary>
-    /// Create an invite link to join an organisation
-    /// </summary>
-    [HttpPost("{id}/invite")]
-    [ProducesResponseType(typeof(CreateOrganizationDto), StatusCodes.Status201Created)]
-    [ProducesResponseType(typeof(FailureResponseDto<string>), (int)HttpStatusCode.Conflict)]
-    [ProducesResponseType(typeof(FailureResponseDto<string>), (int)HttpStatusCode.NotFound)]
-    [ProducesResponseType(typeof(FailureResponseDto<string>), (int)HttpStatusCode.Unauthorized)]
-    [ProducesResponseType(typeof(FailureResponseDto<string>), (int)HttpStatusCode.UnprocessableContent)]
+    // /// <summary>
+    // /// Create an invite link to join an organisation
+    // /// </summary>
+    // [HttpPost("{id}/invite")]
+    // [ProducesResponseType(typeof(CreateOrganizationDto), StatusCodes.Status201Created)]
+    // [ProducesResponseType(typeof(FailureResponseDto<string>), (int)HttpStatusCode.Conflict)]
+    // [ProducesResponseType(typeof(FailureResponseDto<string>), (int)HttpStatusCode.NotFound)]
+    // [ProducesResponseType(typeof(FailureResponseDto<string>), (int)HttpStatusCode.Unauthorized)]
+    // [ProducesResponseType(typeof(FailureResponseDto<string>), (int)HttpStatusCode.UnprocessableContent)]
 
-    public async Task<ActionResult<CreateOrganizationDto>> CreateOrganizationInvite([FromBody] CreateOrganizationInviteDto body, string id)
-    {
-        var inviterId = await authenticationService.GetCurrentUserAsync();
-        body.UserId = inviterId;
-        body.OrganizationId = id;
-        var command = new CreateOrganizationInviteCommand(body);
-        StatusCodeResponse<OrganizationInviteDto> result = await mediator.Send(command);
+    // public async Task<ActionResult<CreateOrganizationDto>> CreateOrganizationInvite([FromBody] CreateOrganizationInviteDto body, string id)
+    // {
+    //     var inviterId = await authenticationService.GetCurrentUserAsync();
+    //     body.UserId = inviterId;
+    //     body.OrganizationId = id;
+    //     var command = new CreateOrganizationInviteCommand(body);
+    //     StatusCodeResponse result = await mediator.Send(command);
 
-        return StatusCode(result.StatusCode, result);
-    }
+    //     return StatusCode(result.StatusCode, result);
+    // }
     /// <summary>
-    /// Create an invite link to join an organisation
+    /// Create and send invite links to join an organisation
     /// </summary>
     [HttpPost("send-invite")]
-    [ProducesResponseType(typeof(CreateOrganizationDto), StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(FailureResponseDto<string>), (int)HttpStatusCode.Conflict)]
-    [ProducesResponseType(typeof(FailureResponseDto<string>), (int)HttpStatusCode.NotFound)]
-    [ProducesResponseType(typeof(FailureResponseDto<string>), (int)HttpStatusCode.Unauthorized)]
-    [ProducesResponseType(typeof(FailureResponseDto<string>), (int)HttpStatusCode.UnprocessableContent)]
+    [ProducesResponseType(typeof(ControllerStatusResponse<CreateAndSendInvitesResponseDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(StatusCodeResponse), (int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(typeof(StatusCodeResponse), (int)HttpStatusCode.Unauthorized)]
+    [ProducesResponseType(typeof(StatusCodeResponse), (int)HttpStatusCode.UnprocessableContent)]
 
     public async Task<ActionResult<CreateOrganizationDto>> CreateOrganizationInvite([FromBody] CreateAndSendInvitesDto body)
     {
         body.InviterId = await authenticationService.GetCurrentUserAsync();
         var command = new CreateAndSendInvitesCommand(body);
-        StatusCodeResponse<object> result = await mediator.Send(command);
+        StatusCodeResponse result = await mediator.Send(command);
 
         return StatusCode(result.StatusCode, new { result.StatusCode, result.Message, result.Data });
     }


### PR DESCRIPTION
<!-- Do not delete this PR template. Just edit it to include the required information -->

# Description

Update the response objects on the Swagger docs to match the actual responses from the endpoint. This improves consistency and intuitiveness.
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

