### PR TITLE
fix: alter the generated documentation for email-template routes to b…

### DIFF
--- a/src/Hng.Web/Filters/Swashbuckle/SnakeCaseDictionaryFilter.cs
+++ b/src/Hng.Web/Filters/Swashbuckle/SnakeCaseDictionaryFilter.cs
@@ -1,0 +1,29 @@
+using System.Text.Json;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Hng.Web.Filters.Swashbuckle;
+
+public class SnakeCaseDictionaryFilter : ISchemaFilter
+{
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        if (schema.Properties.TryGetValue("placeholders", out OpenApiSchema value) && value.AdditionalProperties != null)
+        {
+            OpenApiSchema placeholdersSchema = value;
+            OpenApiObject newExample = new()
+            {
+                ["key"] = new OpenApiString("value"),
+                ["key2"] = new OpenApiString("value")
+            };
+
+            placeholdersSchema.Example = newExample;
+
+            placeholdersSchema.AdditionalProperties = new OpenApiSchema { Type = "string" };
+
+            // Ensure the changes are reflected in the main schema
+            schema.Properties["placeholders"] = placeholdersSchema;
+        }
+    }
+}

--- a/src/Hng.Web/Program.cs
+++ b/src/Hng.Web/Program.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using Prometheus;
 using Hng.Web.ModelStateError;
 using Microsoft.AspNetCore.Mvc;
+using Hng.Web.Filters.Swashbuckle;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -36,6 +37,7 @@ builder.Services.AddApplicationConfig(builder.Configuration);
 builder.Services.AddInfrastructureConfig(builder.Configuration.GetConnectionString("DefaultConnectionString"));
 builder.Services.AddSwaggerGen(c =>
 {
+    c.SchemaFilter<SnakeCaseDictionaryFilter>();
     var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
     var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
     c.IncludeXmlComments(xmlPath);


### PR DESCRIPTION

<!-- Do not delete this PR template. Just edit it to include the required information -->

# Description
This PR addresses an issue where the generated Swagger documentation for the email-template routes used camel case examples.
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Github Issue Example: Closes #31 -->
