### PR TITLE
Feat: remove a subscriber from the newsletter 

### DIFF
--- a/src/Hng.Application.Test/Features/NewsLetterSubscription/DeleteSubscriberCommandHandlerShould.cs
+++ b/src/Hng.Application.Test/Features/NewsLetterSubscription/DeleteSubscriberCommandHandlerShould.cs
@@ -1,0 +1,70 @@
+using Hng.Application.Features.NewsLetterSubscription.Commands;
+using Hng.Application.Features.NewsLetterSubscription.Handlers;
+using Hng.Domain.Entities;
+using Hng.Infrastructure.Repository.Interface;
+using Moq;
+using Xunit;
+
+namespace Hng.Application.Test.Features.NewsLetterSubscription
+{
+    public class DeleteSubscriberHandlerShould
+    {
+        private readonly Mock<IRepository<NewsLetterSubscriber>> _mockRepository;
+        private readonly DeleteSubscriberHandler _handler;
+
+        public DeleteSubscriberHandlerShould()
+        {
+            _mockRepository = new Mock<IRepository<NewsLetterSubscriber>>();
+            _handler = new DeleteSubscriberHandler(_mockRepository.Object);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldDeleteSubscriber_WhenSubscriberExists()
+        {
+            var subscriberId = Guid.NewGuid();
+            var subscriber = new NewsLetterSubscriber { Id = subscriberId };
+            var command = new DeleteSubscriberCommand(subscriberId);
+
+            _mockRepository.Setup(r => r.GetAsync(subscriberId))
+                .ReturnsAsync(subscriber);
+
+            _mockRepository.Setup(r => r.UpdateAsync(It.IsAny<NewsLetterSubscriber>()))
+                .Returns(Task.CompletedTask);
+
+            _mockRepository.Setup(r => r.SaveChanges())
+                .Returns(Task.CompletedTask);
+
+            // Act
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(200, result.StatusCode);
+            Assert.Equal("Subscriber deleted successfully.", result.Message);
+
+            _mockRepository.Verify(r => r.GetAsync(subscriberId), Times.Once);
+            _mockRepository.Verify(r => r.UpdateAsync(subscriber), Times.Once);
+            _mockRepository.Verify(r => r.SaveChanges(), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldReturnNotFound_WhenSubscriberDoesNotExist()
+        {
+            var subscriberId = Guid.NewGuid();
+            var command = new DeleteSubscriberCommand(subscriberId);
+
+            _mockRepository.Setup(r => r.GetAsync(subscriberId))
+                .ReturnsAsync((NewsLetterSubscriber)null);
+
+            // Act
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(404, result.StatusCode);
+            Assert.Equal("Subscriber not found.", result.Message);
+
+            _mockRepository.Verify(r => r.GetAsync(subscriberId), Times.Once);
+            _mockRepository.Verify(r => r.UpdateAsync(It.IsAny<NewsLetterSubscriber>()), Times.Never);
+            _mockRepository.Verify(r => r.SaveChanges(), Times.Never);
+        }
+    }
+}

--- a/src/Hng.Application/Features/NewsLetterSubscription/Commands/DeleteSubscriberCommand.cs
+++ b/src/Hng.Application/Features/NewsLetterSubscription/Commands/DeleteSubscriberCommand.cs
@@ -1,0 +1,15 @@
+using Hng.Application.Shared.Dtos;
+using MediatR;
+
+namespace Hng.Application.Features.NewsLetterSubscription.Commands
+{
+    public class DeleteSubscriberCommand : IRequest<BaseResponseDto<bool>>
+    {
+        public Guid Id { get; }
+
+        public DeleteSubscriberCommand(Guid id)
+        {
+            Id = id;
+        }
+    }
+}

--- a/src/Hng.Application/Features/NewsLetterSubscription/Handlers/DeleteSubscriberHandlder.cs
+++ b/src/Hng.Application/Features/NewsLetterSubscription/Handlers/DeleteSubscriberHandlder.cs
@@ -1,0 +1,41 @@
+using Hng.Application.Features.NewsLetterSubscription.Commands;
+using Hng.Application.Shared.Dtos;
+using Hng.Domain.Entities;
+using Hng.Infrastructure.Repository.Interface;
+using MediatR;
+
+namespace Hng.Application.Features.NewsLetterSubscription.Handlers
+{
+    public class DeleteSubscriberHandler : IRequestHandler<DeleteSubscriberCommand, BaseResponseDto<bool>>
+    {
+        private readonly IRepository<NewsLetterSubscriber> _repository;
+
+        public DeleteSubscriberHandler(IRepository<NewsLetterSubscriber> repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<BaseResponseDto<bool>> Handle(DeleteSubscriberCommand request, CancellationToken cancellationToken)
+        {
+            var subscriber = await _repository.GetAsync(request.Id);
+            if (subscriber is null)
+            {
+                return new BaseResponseDto<bool>
+                {
+                    StatusCode = 404,
+                    Message = "Subscriber not found."
+                };
+            }
+
+            subscriber.IsDeleted = true;
+            await _repository.UpdateAsync(subscriber);
+            await _repository.SaveChanges();
+
+            return new BaseResponseDto<bool>
+            {
+                StatusCode = 200,
+                Message = "Subscriber deleted successfully."
+            };
+        }
+    }
+}

--- a/src/Hng.Application/Shared/Dtos/BaseResponseDto.cs
+++ b/src/Hng.Application/Shared/Dtos/BaseResponseDto.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace Hng.Application.Shared.Dtos
+{
+    public class BaseResponseDto<T>
+    {
+        [JsonPropertyName("data")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        [JsonPropertyOrder(3)]
+        public T Data { get; set; }
+        [JsonPropertyName("message")]
+        [JsonPropertyOrder(2)]
+        public string Message { get; set; } = "Request completed successfully.";
+        [JsonPropertyName("status_code")]
+        [JsonPropertyOrder(1)]
+        public int StatusCode { get; set; } = 200;
+    }
+}

--- a/src/Hng.Domain/Entities/NewsLetterSubscriber.cs
+++ b/src/Hng.Domain/Entities/NewsLetterSubscriber.cs
@@ -5,5 +5,6 @@
         public string Email { get; set; }
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
         public DateTime? LeftOn { get; set; }
+        public bool IsDeleted { get; set; } = false;
     }
 }

--- a/src/Hng.Infrastructure/Migrations/20250227230159_AddIsDeletedToNewsLetterSubscriber.Designer.cs
+++ b/src/Hng.Infrastructure/Migrations/20250227230159_AddIsDeletedToNewsLetterSubscriber.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Hng.Infrastructure.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Hng.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250227230159_AddIsDeletedToNewsLetterSubscriber")]
+    partial class AddIsDeletedToNewsLetterSubscriber
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Hng.Infrastructure/Migrations/20250227230159_AddIsDeletedToNewsLetterSubscriber.cs
+++ b/src/Hng.Infrastructure/Migrations/20250227230159_AddIsDeletedToNewsLetterSubscriber.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Hng.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsDeletedToNewsLetterSubscriber : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "NewsLetterSubscribers",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "NewsLetterSubscribers");
+        }
+    }
+}

--- a/src/Hng.Web/Controllers/NewsLetterController.cs
+++ b/src/Hng.Web/Controllers/NewsLetterController.cs
@@ -28,5 +28,15 @@ namespace Hng.Web.Controllers
                 return Unauthorized(new FailureResponseDto<object> { Message = "Email already exists.", Error = StatusCodes.Status401Unauthorized.ToString(), Data = null });
             return StatusCode((int)HttpStatusCode.Created, new SuccessResponseDto<NewsLetterSubscriptionDto> { Message = "Email was successfully stored.", Data = result });
         }
+
+        [HttpDelete("{Id}")]
+        [EndpointDescription("Unsubscribe from News Letter")]
+        [ProducesResponseType<BaseResponseDto<bool>>((int)HttpStatusCode.OK)]
+        [ProducesResponseType<BaseResponseDto<object>>((int)HttpStatusCode.NotFound)]
+        public async Task<IActionResult> RemoveSubscriber(Guid Id)
+        {
+            var result = await _mediator.Send(new DeleteSubscriberCommand(Id));
+            return StatusCode(result.StatusCode, new BaseResponseDto<bool> { Message = result.Message, Data = result.Data });
+        }
     }
 }


### PR DESCRIPTION
# Description
Closes #404 

# Changes proposed
- [x] Added IsDeleted to NewsLetterSubscriber entity for soft deletion
- [x] Created a migration to apply the IsDeleted column to the database
- [x] Added a base response dto in Hng.Application project under Shared/Dto folder to serve as a general response for both success and failure responses. 
- [x] Added DELETE /api/v1/news-letter/:id endpoint to Newsletter controller
- [x] Created a command and a command handler in the Hng.Application project to handle the interface and logic of the endpoint
- [x] Added unit tests for the command handler  in the Hng.Application.Test project

# Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the **dev branch** (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

# Screenshots/Videos
- IsDeleted added after migration
![Screenshot 2025-02-28 at 2 02 24 AM](https://github.com/user-attachments/assets/f51bb0a7-da89-4482-90fb-c32c4113e205)
![Screenshot 2025-02-28 at 2 06 00 AM](https://github.com/user-attachments/assets/934965a9-5429-4754-a67b-3311ac68d719)
- Successful response 
![Screenshot 2025-02-28 at 2 11 25 AM](https://github.com/user-attachments/assets/79acc0b1-d746-4fc6-ab65-2f32bc622791)
- Bad request returned for invalid id format (Guid)
![Screenshot 2025-02-28 at 2 11 40 AM](https://github.com/user-attachments/assets/8eeba28e-f3af-4a88-aa27-9513dd3b51c5)
- All tests passing 
![Screenshot 2025-02-28 at 2 12 52 AM](https://github.com/user-attachments/assets/9d45d501-ef3a-4228-94c7-e01471b490a0)
